### PR TITLE
Fix various spelling mistakes in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If error occurred at compile/runtime operation, please refer [error list](./docs
 
 ### Tips  
 [How-to](./how-to) page includes following explanation.  
-- profilier;  
+- profiler;  
 - validation between x86 and DRP-AI;  
 - etc.  
 

--- a/docs/Compile_API.md
+++ b/docs/Compile_API.md
@@ -60,15 +60,15 @@ Keep **0x0** to "addr_map_start" for Renesas RZ/V Evaluation Board Kit.
 
 
 ----
-## Appendix 1 : Argments of sample scripts
+## Appendix 1 : Arguments of sample scripts
 
 |option|Note|
 |----|----|
 |-o/--output_dir|Output directory to save compile results.|
 |-i/--input_name|AI model input node name. (Not required for pytorch models)|
 |-s/--input_shape|AI model input node shape|
-|[option]-d/--drp_compiler_dir|DRP-AI Translator installed directory. This argument can be omitted by setting environment variables as shown follwoing: "export TRANSLATOR=<.../drp-ai_translator> "|
-|[option]-t/--toolchain_dir|SDK(Cross compiler) installed directory. This argument can be omitted by setting environment variables as shown follwoing: "export SDK=</opt/poky/3.1.21>"|
+|[option]-d/--drp_compiler_dir|DRP-AI Translator installed directory. This argument can be omitted by setting environment variables as shown following: "export TRANSLATOR=<.../drp-ai_translator> "|
+|[option]-t/--toolchain_dir|SDK(Cross compiler) installed directory. This argument can be omitted by setting environment variables as shown following: "export SDK=</opt/poky/3.1.21>"|
 |[option]--level | Optimization level at compile. "1" is the default and compiles with optimal settings. If "0" is set to this option,  complex models can be deployed, but inference speed is slower.|
 
 [*1]: DRP-AI TVM is powered by EdgeCortix MERA™ Compiler Framework.

--- a/docs/Model_List.md
+++ b/docs/Model_List.md
@@ -76,7 +76,7 @@ Below is a list of AI models that Renesas has verified for conversion with the D
 |Monodepth2 mono_640x192 encoder            |Depth            |PyTorch             |21259ms |74ms  |51774ms |55ms  |25892ms |51ms  |
 |SC-Depth resnet18_depth_256 dispnet        |Depth            |PyTorch             |49419ms |885ms |121715ms|1313ms|61011ms |925ms |
 |SC-Depth resnet50_depth_256 dispnet        |Depth            |PyTorch             |26831ms |1081ms|65763ms |2300ms|32908ms |1237ms|
-|FaceNet                                    |Face Detection   |Tensorflow          |27875ms |422ms |80234ms |917ms |45130ms |481ms |
+|FaceNet                                    |Face Detection   |TensorFlow          |27875ms |422ms |80234ms |917ms |45130ms |481ms |
 |ConvNeXt atto                              |Classification   |pytorch-image-models|12005ms |151ms |29235ms |118ms |14650ms |112ms |
 |ConvNeXt femto                             |Classification   |pytorch-image-models|12015ms |151ms |29227ms |118ms |14665ms |113ms |
 |ConvNeXt femto ols                         |Classification   |pytorch-image-models|12004ms |152ms |29228ms |118ms |14649ms |112ms |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,9 @@
-# Documents 
+# Documents
 
 ## List of contents
 
  - [Compile API](./Compile_API.md) ... Reference for compile API.
  - [Runtime API](./Runtime_API.md) ... Reference for runtime API.
  - [Model list](./Model_List.md) ... Evaluated model list.
- - [Error list](./Error_List.md) ... Compile and runtiem error list.
+ - [Error list](./Error_List.md) ... Compile and runtime error list.
  - [DRP-AI Pre-processing Runtime Documentation](./PreRuntime.md) ... Reference for DRP-AI Pre-processing Runtime Specification.

--- a/docs/Runtime_API.md
+++ b/docs/Runtime_API.md
@@ -45,7 +45,7 @@ int MeraDrpRuntimeWrapper::GetNumOutput(void);
  - **GetNumOutput()** method returns the number of output layers of the inference model deployed to the MeraDrpRuntimeWrapper object.
 
 ### Return
- - The number of out put node. A non-zero positive integer. A value of 0 or negative indicates that a problem occurred during the processing of this function.
+ - The number of output nodes. A non-zero positive integer. A value of 0 or negative indicates that a problem occurred during the processing of this function.
 
 ----
 ## GetOutput


### PR DESCRIPTION
I've seen a few spelling typos as I've been reading through the documentation. May as well get them fixed!